### PR TITLE
Update rocq-core lower bound from 9.0 to 9.3

### DIFF
--- a/rocq-lean-import.opam
+++ b/rocq-lean-import.opam
@@ -16,7 +16,7 @@ run-test: [make "-j%{jobs}%" "test"]
 install: [make "install"]
 depends: [
   "ocaml" {>= "4.09.0"}
-  "rocq-core" {>= "9.0~" | = "dev"}
+  "rocq-core" {>= "9.3~" | = "dev"}
   "rocq-stdlib"
 ]
 conflict-class: [


### PR DESCRIPTION
## Summary
- Update `rocq-core` dependency lower bound from `>= "9.0~"` to `>= "9.3~"`
- Master no longer builds with any released Rocq version (9.0, 9.1, or 9.2) due to API adaptations:
  - `50802fb` Adapt to rocq-prover/rocq#21531 (stricter type-in-type) - adds `check_eliminations` field not present in Rocq 9.2
  - `b22841b` Adapt to rocq-prover/rocq#21767 (qglobal is not qvar)

## Test plan
- Verified v0.0.2 (last release) only builds with Rocq 9.2
- Verified current master fails on Rocq 9.0 (`UGraph.enforce_constraint` API change), 9.1 (`PConstraints` module renamed), and 9.2 (`check_eliminations` field missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)