### PR TITLE
Translated universe instances

### DIFF
--- a/dumps/universe_instances
+++ b/dumps/universe_instances
@@ -1,0 +1,72 @@
+1 #NS 0 UniverseBox
+2 #NS 0 u
+3 #NS 0 v
+1 #UP 2
+2 #UP 3
+4 #NS 0 α
+3 #US 1
+0 #ES 3
+4 #UM 3 2
+5 #US 4
+1 #ES 5
+2 #EP #BD 4 0 1
+#AX 1 2 2 3
+5 #NS 0 Nat
+6 #US 0
+3 #ES 6
+6 #NS 5 zero
+7 #NS 5 succ
+4 #EC 5
+8 #NS 0 n
+5 #EP #BD 8 4 4
+9 #NS 5 rec
+10 #NS 0 motive
+11 #NS 0 t
+6 #ES 1
+7 #EP #BD 11 4 6
+12 #NS 0 zero
+8 #EV 0
+9 #EC 6
+10 #EA 8 9
+13 #NS 0 succ
+14 #NS 0 n_ih
+11 #EV 2
+12 #EA 11 8
+13 #EV 3
+14 #EC 7
+15 #EV 1
+16 #EA 14 15
+17 #EA 13 16
+18 #EP #BD 14 12 17
+19 #EP #BD 8 4 18
+20 #EA 13 8
+21 #EP #BD 11 4 20
+22 #EP #BD 13 19 21
+23 #EP #BD 12 10 22
+24 #EP #BI 10 7 23
+25 #EL #BD 13 19 15
+26 #EL #BD 12 10 25
+27 #EL #BD 10 7 26
+28 #EA 15 8
+29 #EC 9 1
+30 #EA 29 13
+31 #EA 30 11
+32 #EA 31 15
+33 #EA 32 8
+34 #EA 28 33
+35 #EL #BD 8 4 34
+36 #EL #BD 13 19 35
+37 #EL #BD 12 10 36
+38 #EL #BD 10 7 37
+#IND 0 5 3 2 6 4 7 5
+15 #NS 0 universeValue
+39 #EC 1 1 2
+40 #EA 39 8
+41 #EP #BD 4 0 40
+#AX 15 41 2 3
+16 #NS 0 universeValueType
+42 #EC 1 0 6
+43 #EA 42 4
+44 #EC 15 0 6
+45 #EA 44 4
+#DEF 16 43 45

--- a/dumps/universe_instances.lean
+++ b/dumps/universe_instances.lean
@@ -1,0 +1,6 @@
+universe u v
+
+axiom UniverseBox (α : Type u) : Type (max (u + 1) v)
+axiom universeValue (α : Type u) : UniverseBox.{u, v} α
+
+noncomputable def universeValueType : UniverseBox.{0, 1} Nat := universeValue Nat

--- a/src/lean.ml
+++ b/src/lean.ml
@@ -310,6 +310,10 @@ type uconv = {
   levels : Level.t Universe.Map.t;
       (** Map from algebraic universes to levels (only levels representing an
           algebraic) *)
+  direct : Level.Set.t;
+      (** Named Lean levels that occur directly in universe instances. Levels
+          that only occur below an algebraic successor do not need to be exposed
+          as parameters of the translated declaration. *)
   graph : UGraph.t;
 }
 
@@ -384,7 +388,7 @@ let rec level_of_sets uconv n =
 
 let to_univ_level u uconv =
   match Universe.level u with
-  | Some l -> (uconv, l)
+  | Some l -> ({ uconv with direct = Level.Set.add l uconv.direct }, l)
   | None ->
     (match is_sets u with
     | Some n -> level_of_sets uconv n
@@ -443,9 +447,21 @@ let height n body =
 type instantiation = {
   ref : GlobRef.t;
   algs : Universe.t list;
-      (** For each extra universe, produce the algebraic it corresponds to (the
-          initial universes are replaced by the appropriate Var) *)
+      (** Full Rocq universe instance as algebraic universes over the Lean
+          universe parameters. *)
 }
+
+let universe_var i = Universe.make (Level.var i)
+let identity_algs n = List.init n universe_var
+
+let non_sprop_univ_count nunivs i =
+  let rec loop j acc =
+    if j = nunivs then acc
+    else
+      let acc = if i land (1 lsl j) = 0 then acc + 1 else acc in
+      loop (j + 1) acc
+  in
+  loop 0 0
 
 (*
 Lean classifies inductives in the following way:
@@ -583,6 +599,7 @@ let start_uconv univs i =
       graph = Global.universes ();
       map = N.Map.empty;
       levels = Universe.Map.empty;
+      direct = Level.Set.empty;
     }
   in
   let uconv, set1 = level_of_sets uconv 1 in
@@ -602,36 +619,30 @@ let start_uconv univs i =
   in
   aux uconv i univs
 
-let rec make_unames univs ounivs =
-  match (univs, ounivs) with
-  | _, [] ->
-    List.map (fun u -> Name (Id.of_string_soft (Level.to_string u))) univs
-  | _u :: univs, o :: ounivs -> N.to_name o :: make_unames univs ounivs
-  | [], _ :: _ -> assert false
-
-let univ_entry_gen { map; levels; graph } ounivs =
-  let ounivs =
+let univ_entry_gen { map; levels; direct; graph } ounivs =
+  let original_pairs =
     CList.map_filter
       (fun u ->
         let v = N.Map.get u map in
         match v with LSProp -> None | Level v -> Some (u, v))
       ounivs
   in
-  let ounivs, univs = List.split ounivs in
-  let univs, algs =
-    if Universe.Map.is_empty levels then (univs, [])
-    else
-      let univs = List.rev univs in
-      (* add the new levels to univs, add constraints between maxes
-         (eg max(a,b) <= max(a,b,c)) *)
-      let univs, algs =
-        Universe.Map.fold
-          (fun alg l (univs, algs) -> (l :: univs, alg :: algs))
-          levels (univs, [])
-      in
-      let univs = List.rev univs in
-      (univs, algs)
+  let original_levels = List.map snd original_pairs in
+  let original_instance =
+    Instance.of_array ([||], Array.of_list original_levels)
   in
+  let original_subst = snd (make_instance_subst original_instance) in
+  let direct_pairs =
+    List.filter (fun (_, l) -> Level.Set.mem l direct) original_pairs
+  in
+  let extra_pairs =
+    Universe.Map.fold (fun alg l acc -> (alg, l) :: acc) levels [] |> List.rev
+  in
+  let decl_pairs =
+    List.map (fun (u, l) -> (Some u, Universe.make l, l)) direct_pairs
+    @ List.map (fun (alg, l) -> (None, alg, l)) extra_pairs
+  in
+  let univs = List.map (fun (_, _, l) -> l) decl_pairs in
   let uset =
     List.fold_left (fun kept l -> Level.Set.add l kept) Level.Set.empty univs
   in
@@ -643,11 +654,26 @@ let univ_entry_gen { map; levels; graph } ounivs =
       (fun (a, _, b) -> Level.Set.mem a uset || Level.Set.mem b uset)
       csts
   in
-  let unames = { quals = [||]; univs = Array.of_list (make_unames univs ounivs)} in
-  let univs = Instance.of_array ([||], Array.of_list univs) in
-  let uctx = UContext.make unames (univs, PConstraints.of_univs csts) in
-  let subst = snd (make_instance_subst univs) in
-  let algs = List.rev_map (subst_univs_level_universe subst) algs in
+  let unames =
+    {
+      quals = [||];
+      univs =
+        Array.of_list
+          (List.map
+             (function
+               | Some u, _, _ -> N.to_name u
+               | None, _, l -> Name (Id.of_string_soft (Level.to_string l)))
+             decl_pairs);
+    }
+  in
+  let univs_inst = Instance.of_array ([||], Array.of_list univs) in
+  let uctx = UContext.make unames (univs_inst, PConstraints.of_univs csts) in
+  let algs =
+    List.map
+      (fun (_, alg, _) ->
+        simplify_universe (subst_univs_level_universe original_subst alg))
+      decl_pairs
+  in
   (uctx, algs)
 
 let univ_entry a b =
@@ -1204,12 +1230,11 @@ and instantiate n univs uconv =
     in
     Some u
   in
-  let extra =
+  let univs =
     List.map
       (fun alg -> simplify_universe (UnivSubst.subst_univs_universe subst alg))
       inst.algs
   in
-  let univs = List.concat [ univs; extra ] in
   let uconv, univs =
     CList.fold_left_map (fun uconv u -> to_univ_level u uconv) uconv univs
   in
@@ -1306,19 +1331,24 @@ and declare_ind { name = n; params; ty; ctors; univs } i =
     Feedback.msg_info Pp.(Id.print def_name ++ str " is predeclared (cumulative)");
     (* The Rocq cumul definitions take four universes [r s s1 rs1] where
        [s1] stands for Lean's [s+1] and [rs1] for Lean's [max(r+1, s+1)].
-       Lean provides two universes [r; s], so we supply two [algs] that
-       synthesise the missing two on every use.  For [ULift.rec] at scheme
-       j = 2*i (motive non-SProp), Lean also provides [motive] as the first
-       universe, shifting [r] and [s] to positions 1 and 2 in [Level.var].
-       For [ULift.rec] at j = 2*i+1 (motive SProp), [motive] is filtered
-       out by [int_of_univs] so the indices match the non-rec case. *)
+       Lean provides two universes [r; s], so the Rocq instance is represented
+       by four algebraic universes over the Lean instance.  For [ULift.rec] at
+       scheme j = 2*i (motive non-SProp), Lean also provides [motive] as the
+       first universe, shifting [r] and [s] to positions 1 and 2 in [Level.var].
+       For [ULift.rec] at j = 2*i+1 (motive SProp), [motive] is filtered out by
+       [int_of_univs] so the indices match the non-rec case. *)
     let algs_of r_idx s_idx =
       let r = Universe.make (Level.var r_idx) in
       let s = Universe.make (Level.var s_idx) in
-      [ Universe.super s; Universe.sup (Universe.super r) (Universe.super s) ]
+      [
+        r;
+        s;
+        Universe.super s;
+        Universe.sup (Universe.super r) (Universe.super s);
+      ]
     in
     let algs_2 = algs_of 0 1 in
-    let algs_rec = algs_of 1 2 in
+    let algs_rec = universe_var 0 :: algs_of 1 2 in
     let ulift_ref = Rocqlib.lib_ref (cumul_reg n) in
     let inst = { ref = ulift_ref; algs = algs_2 } in
     add_declared n i inst;
@@ -1355,7 +1385,12 @@ and declare_ind { name = n; params; ty; ctors; univs } i =
         | 1 -> UContext.empty
         | _ -> assert false
       in
-      (mind, [], ind_name, [ cname ], univs, squashy)
+      ( mind,
+        identity_algs (non_sprop_univ_count 1 i),
+        ind_name,
+        [ cname ],
+        univs,
+        squashy )
     | Some
         ( ((Nat | Nat_le | Or | And | Fin | UInt32 | Char) as k),
           _,
@@ -1607,7 +1642,7 @@ and declare_ind { name = n; params; ty; ctors; univs } i =
     in
     let algs =
       if sort = SchemeSProp then algs
-      else List.map (UnivSubst.subst_univs_universe liftu) algs
+      else universe_var 0 :: List.map (UnivSubst.subst_univs_universe liftu) algs
     in
     let elim = { ref = elim; algs } in
     let j =
@@ -1729,7 +1764,8 @@ let declare_quot quot_name =
               ^ if i = 0 then "" else "_inst" ^ string_of_int i
             in
             let ref = Rocqlib.lib_ref reg in
-            let () = add_declared lean i { ref; algs = [] } in
+            let algs = identity_algs (non_sprop_univ_count nunivs i) in
+            let () = add_declared lean i { ref; algs } in
             loop (i + 1)
         in
         loop 0)

--- a/src/lean.ml
+++ b/src/lean.ml
@@ -310,6 +310,8 @@ type uconv = {
   levels : Level.t Universe.Map.t;
       (** Map from algebraic universes to levels (only levels representing an
           algebraic) *)
+  direct : Level.Set.t;
+      (** Source levels exposed directly in the translated declaration. *)
   graph : UGraph.t;
 }
 
@@ -385,7 +387,7 @@ let rec level_of_sets uconv n =
 
 let to_univ_level u uconv =
   match Universe.level u with
-  | Some l -> (uconv, l)
+  | Some l -> ({ uconv with direct = Level.Set.add l uconv.direct }, l)
   | None ->
     (match is_sets u with
     | Some n -> level_of_sets uconv n
@@ -446,9 +448,20 @@ let height n body =
 type instantiation = {
   ref : GlobRef.t;
   algs : Universe.t list;
-      (** For each extra universe, produce the algebraic it corresponds to (the
-          initial universes are replaced by the appropriate Var) *)
+      (** Complete Rocq instance, expressed over Lean universe parameters. *)
 }
+
+let universe_var i = Universe.make (Level.var i)
+let identity_algs n = List.init n universe_var
+
+let non_sprop_univ_count nunivs i =
+  let rec loop j acc =
+    if j = nunivs then acc
+    else
+      let acc = if i land (1 lsl j) = 0 then acc + 1 else acc in
+      loop (j + 1) acc
+  in
+  loop 0 0
 
 (*
 Lean classifies inductives in the following way:
@@ -586,6 +599,7 @@ let start_uconv univs i =
       graph = Global.universes ();
       map = N.Map.empty;
       levels = Universe.Map.empty;
+      direct = Level.Set.empty;
     }
   in
   let uconv, set1 = level_of_sets uconv 1 in
@@ -605,36 +619,30 @@ let start_uconv univs i =
   in
   aux uconv i univs
 
-let rec make_unames univs ounivs =
-  match (univs, ounivs) with
-  | _, [] ->
-    List.map (fun u -> Name (Id.of_string_soft (Level.to_string u))) univs
-  | _u :: univs, o :: ounivs -> N.to_name o :: make_unames univs ounivs
-  | [], _ :: _ -> assert false
-
-let univ_entry_gen { map; levels; graph } ounivs =
-  let ounivs =
+let univ_entry_gen { map; levels; direct; graph } ounivs =
+  let original_pairs =
     CList.map_filter
       (fun u ->
         let v = N.Map.get u map in
         match v with LSProp -> None | Level v -> Some (u, v))
       ounivs
   in
-  let ounivs, univs = List.split ounivs in
-  let univs, algs =
-    if Universe.Map.is_empty levels then (univs, [])
-    else
-      let univs = List.rev univs in
-      (* add the new levels to univs, add constraints between maxes
-         (eg max(a,b) <= max(a,b,c)) *)
-      let univs, algs =
-        Universe.Map.fold
-          (fun alg l (univs, algs) -> (l :: univs, alg :: algs))
-          levels (univs, [])
-      in
-      let univs = List.rev univs in
-      (univs, algs)
+  let original_levels = List.map snd original_pairs in
+  let original_instance =
+    Instance.of_array ([||], Array.of_list original_levels)
   in
+  let original_subst = snd (make_instance_subst original_instance) in
+  let direct_pairs =
+    List.filter (fun (_, l) -> Level.Set.mem l direct) original_pairs
+  in
+  let extra_pairs =
+    Universe.Map.fold (fun alg l acc -> (alg, l) :: acc) levels [] |> List.rev
+  in
+  let decl_pairs =
+    List.map (fun (u, l) -> (Some u, Universe.make l, l)) direct_pairs
+    @ List.map (fun (alg, l) -> (None, alg, l)) extra_pairs
+  in
+  let univs = List.map (fun (_, _, l) -> l) decl_pairs in
   let uset =
     List.fold_left (fun kept l -> Level.Set.add l kept) Level.Set.empty univs
   in
@@ -646,11 +654,26 @@ let univ_entry_gen { map; levels; graph } ounivs =
       (fun (a, _, b) -> Level.Set.mem a uset || Level.Set.mem b uset)
       csts
   in
-  let unames = { quals = [||]; univs = Array.of_list (make_unames univs ounivs)} in
-  let univs = Instance.of_array ([||], Array.of_list univs) in
-  let uctx = UContext.make unames (univs, PConstraints.of_univs csts) in
-  let subst = snd (make_instance_subst univs) in
-  let algs = List.rev_map (subst_univs_level_universe subst) algs in
+  let unames =
+    {
+      quals = [||];
+      univs =
+        Array.of_list
+          (List.map
+             (function
+               | Some u, _, _ -> N.to_name u
+               | None, _, l -> Name (Id.of_string_soft (Level.to_string l)))
+             decl_pairs);
+    }
+  in
+  let univs_inst = Instance.of_array ([||], Array.of_list univs) in
+  let uctx = UContext.make unames (univs_inst, PConstraints.of_univs csts) in
+  let algs =
+    List.map
+      (fun (_, alg, _) ->
+        simplify_universe (subst_univs_level_universe original_subst alg))
+      decl_pairs
+  in
   (uctx, algs)
 
 let univ_entry a b =
@@ -1208,12 +1231,11 @@ and instantiate n univs uconv =
     in
     Some u
   in
-  let extra =
+  let univs =
     List.map
       (fun alg -> simplify_universe (UnivSubst.subst_univs_universe subst alg))
       inst.algs
   in
-  let univs = List.concat [ univs; extra ] in
   let uconv, univs =
     CList.fold_left_map (fun uconv u -> to_univ_level u uconv) uconv univs
   in
@@ -1309,21 +1331,19 @@ and declare_ind { name = n; params; ty; ctors; univs } i =
     let def_name = name_for_core n i in
     let cumul_reg nm = "lean." ^ Id.to_string (name_for_core nm i) ^ ".cumul" in
     Feedback.msg_info Pp.(Id.print def_name ++ str " is predeclared (cumulative)");
-    (* The Rocq cumul definitions take four universes [r s s1 rs1] where
-       [s1] stands for Lean's [s+1] and [rs1] for Lean's [max(r+1, s+1)].
-       Lean provides two universes [r; s], so we supply two [algs] that
-       synthesise the missing two on every use.  For [ULift.rec] at scheme
-       j = 2*i (motive non-SProp), Lean also provides [motive] as the first
-       universe, shifting [r] and [s] to positions 1 and 2 in [Level.var].
-       For [ULift.rec] at j = 2*i+1 (motive SProp), [motive] is filtered
-       out by [int_of_univs] so the indices match the non-rec case. *)
+    (* ULift uses [r; s; s+1; max(r+1,s+1)]; a Type motive shifts r/s to 1/2. *)
     let algs_of r_idx s_idx =
       let r = Universe.make (Level.var r_idx) in
       let s = Universe.make (Level.var s_idx) in
-      [ Universe.super s; Universe.sup (Universe.super r) (Universe.super s) ]
+      [
+        r;
+        s;
+        Universe.super s;
+        Universe.sup (Universe.super r) (Universe.super s);
+      ]
     in
     let algs_2 = algs_of 0 1 in
-    let algs_rec = algs_of 1 2 in
+    let algs_rec = universe_var 0 :: algs_of 1 2 in
     let ulift_ref = Rocqlib.lib_ref (cumul_reg n) in
     let inst = { ref = ulift_ref; algs = algs_2 } in
     add_declared n i inst;
@@ -1360,7 +1380,12 @@ and declare_ind { name = n; params; ty; ctors; univs } i =
         | 1 -> UContext.empty
         | _ -> assert false
       in
-      (mind, [], ind_name, [ cname ], univs, squashy)
+      ( mind,
+        identity_algs (non_sprop_univ_count 1 i),
+        ind_name,
+        [ cname ],
+        univs,
+        squashy )
     | Some
         ( ((Nat | Nat_le | Or | And | Fin | UInt32 | Char) as k),
           _,
@@ -1612,7 +1637,7 @@ and declare_ind { name = n; params; ty; ctors; univs } i =
     in
     let algs =
       if sort = SchemeSProp then algs
-      else List.map (UnivSubst.subst_univs_universe liftu) algs
+      else universe_var 0 :: List.map (UnivSubst.subst_univs_universe liftu) algs
     in
     let elim = { ref = elim; algs } in
     let j =
@@ -1735,7 +1760,8 @@ let declare_quot quot_name =
               ^ if i = 0 then "" else "_inst" ^ string_of_int i
             in
             let ref = Rocqlib.lib_ref reg in
-            let () = add_declared lean i { ref; algs = [] } in
+            let algs = identity_algs (non_sprop_univ_count nunivs i) in
+            let () = add_declared lean i { ref; algs } in
             loop (i + 1)
         in
         loop 0)

--- a/tests/_CoqProject
+++ b/tests/_CoqProject
@@ -9,3 +9,4 @@ anomaly_print_projections.v
 pnni.v
 ulift.v
 rec_single_ctor.v
+universe_instances.v

--- a/tests/_CoqProject
+++ b/tests/_CoqProject
@@ -10,3 +10,4 @@ pnni.v
 ulift.v
 rec_single_ctor.v
 lowercase_hex.v
+universe_instances.v

--- a/tests/universe_instances.v
+++ b/tests/universe_instances.v
@@ -1,0 +1,12 @@
+From LeanImport Require Import Lean.
+
+Lean Import "../dumps/universe_instances".
+
+Universe a b.
+Constraint Set < a.
+Constraint a < b.
+
+(* The Lean parameters occur only inside successor/maximum expressions, so
+   the translated declaration has exactly the two universes used by its type. *)
+Check UniverseBox@{a b} : Type@{a} -> Type@{b}.
+Check universeValueType : UniverseBox_inst1 Nat.


### PR DESCRIPTION
The importer previously formed Rocq universe instances from an implicit prefix of Lean parameters and a separately stored suffix for synthesized `max`/`succ` levels. It now stores the complete instance recipe and declares only directly used source levels plus synthesized algebraic levels; this fixes the universe-constraint failure at cslib's `Int64.toInt_minValue`.