### PR TITLE
Fix dependent projection types and relevance

### DIFF
--- a/dumps/dependent_sprop_projection
+++ b/dumps/dependent_sprop_projection
@@ -1,0 +1,114 @@
+1 #NS 0 Subtype
+2 #NS 0 u
+1 #UP 2
+3 #NS 0 α
+0 #ES 1
+4 #NS 0 p
+5 #NS 0 a
+6 #NS 5 _@
+7 #NS 6 _internal
+8 #NS 7 _hyg
+9 #NI 8 0
+1 #EV 0
+2 #ES 0
+3 #EP #BD 9 1 2
+2 #US 0
+3 #UM 2 1
+4 #ES 3
+5 #EP #BD 4 3 4
+6 #EP #BI 3 0 5
+10 #NS 1 mk
+11 #NS 0 val
+7 #EV 1
+12 #NS 0 property
+8 #EA 7 1
+9 #EC 1 1
+10 #EV 3
+11 #EA 9 10
+12 #EV 2
+13 #EA 11 12
+14 #EP #BD 12 8 13
+15 #EP #BD 11 7 14
+16 #EP #BI 4 3 15
+17 #EP #BI 3 0 16
+13 #NS 1 rec
+14 #NS 0 u_1
+4 #UP 14
+15 #NS 0 motive
+16 #NS 0 t
+18 #EA 9 7
+19 #EA 18 1
+20 #ES 4
+21 #EP #BD 16 19 20
+17 #NS 0 mk
+22 #EA 12 1
+23 #EC 10 1
+24 #EV 4
+25 #EA 23 24
+26 #EA 25 10
+27 #EA 26 7
+28 #EA 27 1
+29 #EA 12 28
+30 #EP #BD 12 22 29
+31 #EP #BD 11 12 30
+32 #EP #BD 16 13 22
+33 #EP #BD 17 31 32
+34 #EP #BI 15 21 33
+35 #EP #BI 4 3 34
+36 #EP #BI 3 0 35
+37 #EA 10 1
+38 #EA 12 7
+39 #EA 38 1
+40 #EL #BD 12 37 39
+41 #EL #BD 11 10 40
+42 #EL #BD 17 31 41
+43 #EL #BD 15 21 42
+44 #EL #BD 4 3 43
+45 #EL #BI 3 0 44
+#IND 2 1 6 1 10 17 2
+18 #NS 1 val
+19 #NS 0 self
+46 #EP #BD 19 19 12
+47 #EP #BI 4 3 46
+48 #EP #BI 3 0 47
+49 #EJ 1 0 1
+50 #EL #BD 19 19 49
+51 #EL #BD 4 3 50
+52 #EL #BD 3 0 51
+#DEF 18 48 52 2
+20 #NS 1 property
+53 #EC 18 1
+54 #EA 53 12
+55 #EA 54 7
+56 #EA 55 1
+57 #EA 7 56
+58 #EP #BD 19 19 57
+59 #EP #BI 4 3 58
+60 #EP #BI 3 0 59
+61 #EJ 1 1 1
+62 #EL #BD 19 19 61
+63 #EL #BD 4 3 62
+64 #EL #BD 3 0 63
+#DEF 20 60 64 2
+21 #NS 0 subtypeSPropProperty
+22 #NS 0 A
+23 #NS 0 s
+65 #EC 1 0
+66 #EA 65 7
+67 #EA 66 1
+68 #EC 18 0
+69 #EA 68 12
+70 #EA 69 7
+71 #EA 70 1
+72 #EA 7 71
+73 #EP #BD 23 67 72
+74 #EP #BD 4 3 73
+75 #EP #BD 22 2 74
+76 #EC 20 0
+77 #EA 76 12
+78 #EA 77 7
+79 #EA 78 1
+80 #EL #BD 23 67 79
+81 #EL #BD 4 3 80
+82 #EL #BD 22 2 81
+#DEF 21 75 82

--- a/dumps/dependent_sprop_projection.lean
+++ b/dumps/dependent_sprop_projection.lean
@@ -1,0 +1,2 @@
+def subtypeSPropProperty (A : Prop) (p : A → Prop) (s : Subtype p) :
+    p s.val := s.property

--- a/dumps/projection_relevance
+++ b/dumps/projection_relevance
@@ -1,0 +1,77 @@
+1 #NS 0 DepRec
+1 #US 0
+0 #ES 1
+2 #NS 1 mk
+3 #NS 0 proposition
+1 #ES 0
+4 #NS 0 proof
+2 #EV 0
+5 #NS 0 next
+3 #EC 1
+4 #EP #BD 5 3 3
+5 #EP #BD 4 2 4
+6 #EP #BD 3 1 5
+6 #NS 1 rec
+7 #NS 0 u
+2 #UP 7
+8 #NS 0 motive
+9 #NS 0 t
+7 #ES 2
+8 #EP #BD 9 3 7
+10 #NS 0 mk
+11 #NS 0 next_ih
+9 #EV 3
+10 #EA 9 2
+11 #EV 4
+12 #EC 2
+13 #EA 12 9
+14 #EV 2
+15 #EA 13 14
+16 #EV 1
+17 #EA 15 16
+18 #EA 11 17
+19 #EP #BD 11 10 18
+20 #EP #BD 5 3 19
+21 #EP #BD 4 2 20
+22 #EP #BD 3 1 21
+23 #EA 14 2
+24 #EP #BD 9 3 23
+25 #EP #BD 10 22 24
+26 #EP #BI 8 8 25
+27 #EA 9 14
+28 #EA 27 16
+29 #EA 28 2
+30 #EC 6 2
+31 #EA 30 11
+32 #EA 31 9
+33 #EA 32 2
+34 #EA 29 33
+35 #EL #BD 5 3 34
+36 #EL #BD 4 2 35
+37 #EL #BD 3 1 36
+38 #EL #BD 10 22 37
+39 #EL #BD 8 8 38
+#IND 0 1 0 1 2 6
+12 #NS 1 proposition
+13 #NS 0 self
+40 #EP #BD 13 3 1
+41 #EJ 1 0 2
+42 #EL #BD 13 3 41
+#DEF 12 40 42
+14 #NS 1 proof
+43 #EC 12
+44 #EA 43 2
+45 #EP #BD 13 3 44
+46 #EJ 1 1 2
+47 #EL #BD 13 3 46
+#DEF 14 45 47
+15 #NS 1 next
+48 #EJ 1 2 2
+49 #EL #BD 13 3 48
+#DEF 15 4 49
+16 #NS 1 getProof
+17 #NS 0 r
+50 #EC 14
+51 #EA 50 2
+52 #EL #BD 17 3 51
+#DEF 16 45 52

--- a/dumps/projection_relevance.lean
+++ b/dumps/projection_relevance.lean
@@ -1,0 +1,8 @@
+prelude
+
+structure DepRec where
+  proposition : Prop
+  proof : proposition
+  next : DepRec
+
+def DepRec.getProof (r : DepRec) : r.proposition := r.proof

--- a/src/lean.ml
+++ b/src/lean.ml
@@ -1026,14 +1026,48 @@ let unfold_proj_case env evd ~field ~indu ~mib ~mip ~args c =
     }
   in
   let params = Array.map EConstr.Unsafe.to_constr (Array.sub args 0 npar) in
-  let field_ty =
-    let ctor = Constr.mkConstructU (((fst ind, 0), 1), u) in
+  let self_annot = Context.make_annot Name.Anonymous mip.mind_relevance in
+  let self_ty =
+    Constr.mkApp
+      (Constr.mkIndU indu, Array.map EConstr.Unsafe.to_constr args)
+  in
+  let env_self =
+    Environ.push_rel
+      (Context.Rel.Declaration.LocalAssum (self_annot, self_ty)) env
+  in
+  let make_case ~ret_env ~params ~field ~ret_ty c =
+    let case_relev =
+      EConstr.Unsafe.to_relevance
+        (Retyping.relevance_of_type ret_env evd (EConstr.of_constr ret_ty))
+    in
+    let p = ([| self_annot |], ret_ty) in
+    let branch_nas =
+      Array.of_list (List.rev_map Context.Rel.Declaration.get_annot ctor_ctx)
+    in
+    let branch = (branch_nas, Constr.mkRel (nargs - field)) in
+    Constr.mkCase
+      (ci, u, params, (p, case_relev), Constr.NoInvert, c, [| branch |])
+  in
+  let params_self = Array.map (Vars.lift 1) params in
+  let env_inner =
+    Environ.push_rel
+      (Context.Rel.Declaration.LocalAssum
+         (self_annot, Vars.lift 1 self_ty))
+      env_self
+  in
+  let ret_ty =
+    let ctor = Constr.mkConstructU ((ind, 1), u) in
     let ctor_applied = Constr.mkApp (ctor, params) in
     let rec get_field_type i ty =
       match Constr.kind ty with
       | Constr.Prod (_, t, rest) ->
         if i = field then t
-        else get_field_type (i + 1) (Vars.subst1 invalid rest)
+        else
+          let previous =
+            make_case ~ret_env:env_inner ~params:params_self ~field:i
+              ~ret_ty:(Vars.lift 1 t) (Constr.mkRel 1)
+          in
+          get_field_type (i + 1) (Vars.subst1 previous rest)
       | _ -> assert false
     in
     let ctor_ty =
@@ -1042,18 +1076,9 @@ let unfold_proj_case env evd ~field ~indu ~mib ~mip ~args c =
     let ctor_ty =
       EConstr.Unsafe.to_constr (Reductionops.whd_all env evd ctor_ty)
     in
-    get_field_type 0 ctor_ty
+    get_field_type 0 (Vars.lift 1 ctor_ty)
   in
-  let case_relev = mip.mind_relevance in
-  let self_annot = Context.make_annot Name.Anonymous mip.mind_relevance in
-  let ret_ty = Vars.lift 1 field_ty in
-  let p = ([| self_annot |], ret_ty) in
-  let branch_nas =
-    Array.of_list (List.rev_map Context.Rel.Declaration.get_annot ctor_ctx)
-  in
-  let branch = (branch_nas, Constr.mkRel (nargs - field)) in
-  Constr.mkCase
-    (ci, u, params, (p, case_relev), Constr.NoInvert, c, [| branch |])
+  make_case ~ret_env:env_self ~params ~field ~ret_ty c
 
 let lcnt = ref 0
 
@@ -1451,6 +1476,7 @@ and declare_ind { name = n; params; ty; ctors; univs } i =
                  match (fields, Sorts.is_sprop sort, is_recursive) with
                  | [], true, _ -> (None, [], ctys)
                  | _ :: _, false, false ->
+                   (* Proof-only Type records need ordinary induction: they have no primitive eta. *)
                    if
                      List.exists
                        (fun (na, _) ->

--- a/tests/_CoqProject
+++ b/tests/_CoqProject
@@ -10,3 +10,5 @@ pnni.v
 ulift.v
 rec_single_ctor.v
 lowercase_hex.v
+projection_relevance.v
+dependent_sprop_projection.v

--- a/tests/dependent_sprop_projection.v
+++ b/tests/dependent_sprop_projection.v
@@ -1,0 +1,19 @@
+From LeanImport Require Import Lean.
+
+(* A fake projection used in the type of a later field must be lifted under
+   the dependent case predicate, including after a universe becomes SProp. *)
+(* Check the SProp instance eagerly, including its dependent Type recursor. *)
+Set Lean Error Mode "Fail".
+Set Lean Upfront Instantiation.
+Lean Import "../dumps/dependent_sprop_projection".
+
+Check subtypeSPropProperty :
+  forall (A : SProp) (p : A -> SProp) (s : Subtype_inst1 A p),
+    p (Subtype_val_inst1 A p s).
+
+(* A nondependent scheme is not a substitute for Lean's dependent recursor. *)
+Check Subtype_inst1_recl :
+  forall (A : SProp) (p : A -> SProp)
+    (motive : Subtype_inst1 A p -> Type),
+    (forall (x : A) (h : p x), motive (Subtype_mk_inst1 A p x h)) ->
+    forall s : Subtype_inst1 A p, motive s.

--- a/tests/projection_relevance.v
+++ b/tests/projection_relevance.v
@@ -1,0 +1,10 @@
+From LeanImport Require Import Lean.
+
+(* Fake projections are translated to case expressions.  Later field types
+   must refer to the earlier projections, and the return relevance must come
+   from the projected field rather than from the structure. *)
+Lean Import "../dumps/projection_relevance".
+
+Check DepRec_proposition : DepRec -> SProp.
+Check DepRec_proof : forall r, DepRec_proposition r.
+Check DepRec_getProof : forall r, DepRec_proposition r.


### PR DESCRIPTION
Substitute projections into dependent field types and derive case relevance from the instantiated result type. This addresses `Std.Internal.Small.map` failing with `Illegal application (Non-functional construction)` and `Subtype.val` failing with `relevance mark set to relevant but was expected to be irrelevant`.
